### PR TITLE
Fail to detect the architecture in an environment of non-US

### DIFF
--- a/bin/winser
+++ b/bin/winser
@@ -84,7 +84,7 @@ sequence
     })
     .then(function(next, err, npmLocation){
         exec('wmic OS get OSArchitecture', function(err, stdout, stderr) {
-            var architecture = stdout.match(/([2346]{2})\-[bB]it/)[1];
+            var architecture = stdout.match(/(32|64)/)[1];
             next(err, npmLocation, architecture);
         });
     })


### PR DESCRIPTION
Fail to detect the architecture in an environment of non-US.

Because the output of the command `wmic` is different depending on the language environment of the OS.

For example, it would look like this in the Japanese environment.

`wmic OS get OSArchitecture`

```
OSArchitecture
32 ビット
```

Therefore, I changed the regular expression to determine digits only.
