### PR TITLE
Adds secondary NET call for when SESSION is unavailable

### DIFF
--- a/bin/winser
+++ b/bin/winser
@@ -132,13 +132,19 @@ async.series([
         next(error);
     },
     function(next){
-        exec('NET SESSION', function(err, stdout, stderr){
-            if(err || stderr.length !== 0){
-                next("No rights to manage services.");
-            }else{
-                next();
-            }
-        });
+      exec('NET SESSION', function(err, stdout, stderr){
+          if(err || stderr.length !== 0){
+              exec('NET USER', function(err, stdout, stderr){
+                  if(err || stderr.length !== 0){
+                      next("No rights to manage services.");
+                  }else{
+                      next();
+                  }
+              });
+          }else{
+              next();
+          }
+      });
     },
     function(next){
         var error = null;


### PR DESCRIPTION
I am open to suggestions on this, maybe another call in the series? I am not sure how that would look as I am not familiar with the async library. 

The problem: 
In certain environments NET SESSION is unavailable. However, NET USER is available and the user does have permissions to install services. 

The solution: 
Call one more NET command and then throw the error. 

I do not think it is worth calling every NET command but the call to NET SESSION does not completely dictate that installation will succeed or fail.

Thoughts? 