### PR TITLE
Fix typos and using single instance of set

### DIFF
--- a/bin/winser
+++ b/bin/winser
@@ -9,7 +9,7 @@ var path = require('path');
 var options = stdio.getopt({
     'version': {
         key: 'v',
-        description: 'show vinser version and exit'
+        description: 'show winser version and exit'
     },
     'autostart': {
         key: 'a',
@@ -75,10 +75,10 @@ var options = stdio.getopt({
         multiple: true,
         description: 'call nssm "set" command with arguments'
     }
-}, 'vinser [OPTION1] [OPTION2] ...');
+}, 'winser [OPTION1] [OPTION2] ...');
 
 if (options.version){
-    console.log('vinser v' + require("../package.json").version);
+    console.log('winser v' + require("../package.json").version);
     process.exit(0);
 }
 

--- a/bin/winser
+++ b/bin/winser
@@ -310,6 +310,9 @@ async.series([
         if (!options.set || options.set.length === 0){
             next();
         }else{
+            if (typeof(options.set) === 'string') {
+                options.set = [options.set];
+            }
             async.each(options.set,
                 function(arg, callback) {
                     nssmExec('set', arg,


### PR DESCRIPTION
We were trying to set the log output path with the following command:

```
winser -i -a --set "AppStdout some.log"
```

However, this was actually trying to call `set` for each character in the argument. This PR detects the argument as a string then creates a single element array of that argument, so `set` is called only once.