### PR TITLE
add node.js API

### DIFF
--- a/bin/winser
+++ b/bin/winser
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var exec = require('child_process').exec;
 var async = require('async');
 var stdio = require('stdio');
-var path = require('path');
+var winser = require('../index')
 
 var options = stdio.getopt({
     'version': {
@@ -39,7 +37,7 @@ var options = stdio.getopt({
         key: 'p',
         args: 1,
         description: 'path to the node application you want to install as a service',
-        default: process.cwd()
+        default: winser._options.path
     },
     'name': {
         key: 'n',
@@ -78,276 +76,88 @@ var options = stdio.getopt({
 }, 'winser [OPTION1] [OPTION2] ...');
 
 if (options.version){
-    console.log('winser v' + require("../package.json").version);
-    process.exit(0);
-}
-
-function log(message){
-    !options.silent && console.log(message);
-}
-
-function getStartupType(){
-    switch (options.startuptype){
-        case "auto":
-            return "SERVICE_AUTO_START";
-        case "delayed":
-            return "SERVICE_DELAYED_AUTO_START";
-        case "manual":
-            return "SERVICE_DEMAND_START";
-        case "disabled":
-            return "SERVICE_DISABLED";
-        default:
-            return "SERVICE_AUTO_START";
-    }
-}
-
-var quitState = "quit";
-var nssmLocation = null;
-
-function nssmExec(command, arguments, callback){
-    if (arguments === null)
-        arguments = '';
-    exec(nssmLocation + ' '+ command +' "'+ options.name + '" ' + arguments,
-        function(err, stdout, stderr){
-            if (stderr){
-                !options.silent && console.error(stderr);
-            }
-            callback(err || stderr);
-        });
+    console.log('winser v' + winser.version);
+    return process.exit(0);
 }
 
 async.series([
-    function(next){
-        var error = null;
+    function(next) {
         if (!options.install && !options.remove){
-            error = 'Neither install nor remove options set.\nTry "--help" for more information.';
+            return next(new Error('Neither install nor remove options set.\nTry "--help" for more information.'));
         }
-        next(error);
-    },
-    function(next){
-        var error = null;
-        if (process.platform !== "win32"){
-            error = 'Winser can only install services on windows.';
-        }
-        next(error);
-    },
-    function(next){
-        exec('NET SESSION', function(err, stdout, stderr){
-            if(err || stderr.length !== 0){
-                next("No rights to manage services.");
-            }else{
-                next();
-            }
-        });
-    },
-    function(next){
-        var error = null;
-        if (!(fs.existsSync||path.existsSync)(path.join(options.path, "package.json"))){
-            error = '"' + options.path + '" doesn\'t seems to be a node application path.\nIt doesn\'t contains a package.json file.';
-        }else{
-            var appPackage = require(path.join(options.path, "package.json"));
-            if (!options.name)
-                options.name = appPackage.name;
-            if (!options.description)
-                options.description = appPackage.description;
-            if (options.install) {
-                if (!options.startcmd && !options.startwithnpm){
-                    try {
-                        options.startcmd = appPackage.scripts.start;
-                    }catch(e){
-                    }
-                    if (!options.startcmd && appPackage.main){
-                        options.startcmd = "node " + appPackage.main
-                    }
-                }
-            }
-        }
-        next(error);
-    },
-    function(next){
-        if (options.install && options.startwithnpm) {
-            exec('where npm.cmd', function(error, stdout) {
-                if (error !== null) {
-                    next('Can\'t find npm...');
-                    return;
-                }
-                options.startcmd = 'npm start';
-                next();
-            });
-            return;
-        }
+
         next();
     },
-    function(next){
-        exec('wmic CPU get AddressWidth < nul', function(err, stdout) {
-            var arch = '32';
-            if (!err && stdout) {
-                arch = stdout.match(/(32|64)/)[1];
+    function(next) {
+        winser.setSilent(options.silent);
+
+        winser.getAppInfo({
+            path: options.path,
+            name: options.name
+        }, function(error, appInfo) {
+            var message;
+
+            if (error) {
+                return next(error);
             }
-            nssmLocation = '"' + path.join(__dirname, (arch === '64') ? 'nssm64.exe' : 'nssm.exe') + '"';
-            next();
-        });
-    },
-    function(next){
-        if (!options.confirmation) {
-            next();
-        }else{
-            var message = options.install ? 'continue installing "' + options.name + '" as a service? ' :
-                                            'continue uninstalling the "' + options.name + '" service? ';
-            stdio.question(message, ['y', 'n'], function(error, answer){
+
+            if (!options.confirmation) {
+                return next();
+            }
+
+            message = options.install ? 'continue installing "' + appInfo.name + '" as a service? ' :
+                                            'continue uninstalling the "' + appInfo.name + '" service? ';
+
+            stdio.question(message, ['y', 'n'], function(error, answer) {
+                var errorToThrow;
+                var errorMsg;
+
                 if (answer === 'y'){
-                    next();
-                }else{
-                    next(quitState);
+                    return next();
                 }
+
+                if (options.install) {
+                    errorMsg = 'user canceled install';
+                } else {
+                    errorMsg = 'user canceled uninstall';
+                }
+
+                errorToThrow = new Error(errorMsg);
+                errorToThrow.cleanExit = true;
+                next(errorToThrow);
             });
-        }
+        });
     },
-    function(next){
-        if (options.stop && options.remove){
-            exec(nssmLocation + ' status "'+ options.name + '"',
-                function(err, stdout, stderr){
-                    if (!err && !stderr){
-                        var result = stdout.replace(/\0/gi, "").split("\r\n")[0];
-                        if (result === "SERVICE_STOPPED"){
-                            next();
-                        }
-                        nssmExec('stop', null, function(){
-                            next();
-                        });
-                        return;
-                    }
-                    next(err || stderr);
-                });
-        }else{
+    function(next) {
+        if (options.install) {
+            winser.install({
+                path: options.path,
+                name: options.name,
+                displayname: options.displayname,
+                description: options.description,
+                startwithnpm: options.startwithnpm,
+                startcmd: options.startcmd,
+                startuptype: options.startuptype,
+                env: options.env,
+                set: options.set,
+                autostart: options.autostart
+            }, next);
+        } else if (options.remove) {
+            winser.remove({
+                path: options.path,
+                name: options.name,
+                stop: options.stop
+            }, next);
+        } else {
             next();
         }
     },
-    function(next){
-        if(options.install){
-            if (!options.startcmd){
-                next("No start command provided!");
-            }
-            log('Use start command "' + options.startcmd + '".');
-            nssmExec('install', options.startcmd,
-                function(error){
-                    if(!error){
-                        log('The program "' + options.name + '" was installed as a service.');
-                    }
-                    next(error);
-                });
-        }else if(options.remove){
-            nssmExec('remove', ' confirm',
-                function(error){
-                    if(!error){
-                        log('The service for "' + options.name + '" was removed.');
-                        error = quitState;
-                    }
-                    next(error);
-                });
-        }
-    },
-    function(next){
-        nssmExec('set', 'AppDirectory "' + options.path + '"',
-            function(error){
-                if (error)
-                    next('Can\'t set startup folder (' + options.path + ') for service');
-                else
-                    next();
-            });
-    },
-    function(next){
-        if (options.description){
-            nssmExec('set', 'Description "' + options.description + '"',
-                function(error){
-                    if (error)
-                        next('Can\'t set description for service');
-                    else
-                        next();
-                });
-        }else{
-            next();
-        }
-    },
-    function(next){
-        if (options.displayname){
-            nssmExec('set', 'DisplayName "' + options.displayname + '"',
-                function(error){
-                    if (error)
-                        next('Can\'t set display name for service');
-                    else
-                        next();
-                });
-        }else{
-            next();
-        }
-    },
-    function(next){
-        nssmExec('set', 'Start ' + getStartupType(),
-            function(error){
-                if (error)
-                    next('Can\'t set startup type for service');
-                else
-                    next();
-            });
-    },
-    function(next){
-        if (options.env && options.env.length > 0){
-            var envs = Array.isArray(options.env) ? options.env.join(' ') : options.env;
-            nssmExec('set', 'AppEnvironmentExtra ' + envs,
-                function(error){
-                    if (error){
-                        next('Can\'t set environment for service');
-                    }else{
-                        next();
-                    }
-                });
+], function(error) {
+    if (error) {
+        if (error.cleanExit) {
             return;
         }
-        next();
-    },
-    function(next){
-        if (!options.set || options.set.length === 0){
-            next();
-        }else{
-            async.each(options.set,
-                function(arg, callback) {
-                    nssmExec('set', arg,
-                        function(error){
-                            if (error){
-                                callback('Set operation failed (' + arg + ')');
-                            }
-                            else{
-                                callback();
-                            }
-                        });
-                },
-                function(error){
-                    if (error)
-                        next(error);
-                    else
-                        next();
-                });
-        }
-    },
-    function(next){
-        if(options.autostart){
-            nssmExec('start', null,
-                function(error){
-                    if(!error){
-                        log('The service for "' + options.name + '" was started.');
-                        next(quitState);
-                    }else{
-                        next(error);
-                    }
-                });
-        }
-    }
-],
-function(error){
-    if(error === quitState)
-        return;
-    if(error){
+
         console.error(error);
         process.exit(1);
     }

--- a/bin/winser
+++ b/bin/winser
@@ -9,7 +9,7 @@ var path = require('path');
 var options = stdio.getopt({
     'version': {
         key: 'v',
-        description: 'show vinser version and exit'
+        description: 'show winser version and exit'
     },
     'autostart': {
         key: 'a',
@@ -75,10 +75,10 @@ var options = stdio.getopt({
         multiple: true,
         description: 'call nssm "set" command with arguments'
     }
-}, 'vinser [OPTION1] [OPTION2] ...');
+}, 'winser [OPTION1] [OPTION2] ...');
 
 if (options.version){
-    console.log('vinser v' + require("../package.json").version);
+    console.log('winser v' + require("../package.json").version);
     process.exit(0);
 }
 

--- a/index.js
+++ b/index.js
@@ -171,11 +171,19 @@ Winser.prototype.install = function install(localOpts, cb) {
             }
         },
         function(next) {
+            var setOpts
+
             if (!localOpts || !localOpts.set || localOpts.set.length === 0) {
                 return next();
             }
 
-            async.each(localOpts.set, function(arg, callback) {
+            if (typeof localOpts.set === 'string') {
+                setOpts = [localOpts.set]
+            } else {
+                setOpts = localOpts.set
+            }
+
+            async.each(setOpts, function(arg, callback) {
                 nssmExec(options.nssmPath, 'set', appInfo.name, arg, options.silent, function(error) {
                   if (error) {
                       return callback(new Error('Set operation failed (' + arg + ')'));

--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ Winser.prototype.setSilent = function setSilent(silent) {
 }
 
 function checkRequerimentsAndApplyDefaults(action, opts, cb) {
-    var options = opts = {};
+    var options = opts || {};
 
     async.series([
         function(next) {
@@ -373,7 +373,7 @@ function checkRequerimentsAndApplyDefaults(action, opts, cb) {
                     arch = stdout.match(/(32|64)/)[1];
                 }
 
-                options.nssmPath = '"' + path.join(__dirname, (arch === '64') ? 'nssm64.exe' : 'nssm.exe') + '"';
+                options.nssmPath = '"' + path.join(__dirname, './bin', (arch === '64') ? 'nssm64.exe' : 'nssm.exe') + '"';
                 next();
             });
         }
@@ -399,7 +399,7 @@ function getAppInfoFromPkgOrOptions(options, localOptions, cb) {
         appPath = options.path;
     }
 
-    startwithnpm = localOptions.startwithnpm || appInfo.startwithnpm || options.startwithnpm;
+    startwithnpm = (localOptions && localOptions.startwithnpm) || (appInfo && appInfo.startwithnpm) || (options.startwithnpm);
 
     if (startwithnpm) {
         startcmd = 'npm start';

--- a/index.js
+++ b/index.js
@@ -1,0 +1,505 @@
+
+var path = require('path');
+var fs = require('fs');
+var exec = require('child_process').exec;
+var assign = require('object-assign');
+var async = require('async');
+var packageJson = require('./package.json');
+
+function Winser (opts) {
+    var options = opts || {};
+
+    if (!(this instanceof Winser)) {
+        return new Winser(options);
+    }
+
+    options = {
+        path: options.path || process.cwd(),
+        nssmPath: options.nssmPath || undefined,
+        app: options.app || undefined,
+        silent: options.silent || false,
+        startwithnpm: false,
+        startcmd: undefined,
+        startuptype: 'auto',
+        stop: false,
+        autostart: false
+    };
+
+    this._options = options;
+
+    this.log = function log(message) {
+        !options.silent && console.log(message);
+    };
+
+    this.version = packageJson.version;
+};
+
+Winser.prototype.install = function install(localOpts, cb) {
+    var self = this;
+    var args = Array.prototype.slice.call(arguments);
+    var appInfo;
+    var autostart;
+
+    var options = assign({}, self._options);
+
+    if (localOpts && localOpts.path != null) {
+        options.path = localOpts.path;
+    }
+
+    if (localOpts && localOpts.startwithnpm != null) {
+        options.startwithnpm = localOpts.startwithnpm;
+    }
+
+    if (args.length === 1) {
+      cb = localOpts;
+      autostart = options.autostart;
+    } else {
+        if (localOpts && localOpts.autostart != null) {
+            autostart = localOpts.autostart;
+        } else {
+            autostart = options.autostart;
+        }
+    }
+
+    async.waterfall([
+        function(next) {
+            checkRequerimentsAndApplyDefaults('install', options, next);
+        },
+        function(opts, next) {
+            var startcmd;
+            var startuptype;
+
+            options = opts;
+
+            getAppInfoFromPkgOrOptions(options, {
+                path: localOpts && localOpts.path,
+                name: localOpts && localOpts.name,
+                displayname: localOpts && localOpts.displayname,
+                description: localOpts && localOpts.description,
+                startwithnpm: localOpts && localOpts.startwithnpm,
+                startcmd: localOpts && localOpts.startcmd,
+                startuptype: localOpts && localOpts.startuptype
+            }, next);
+        },
+        function(info, next) {
+            appInfo = info;
+
+            if (!appInfo.path) {
+                return next(new Error('No path provided!'));
+            }
+
+            if (!appInfo.name) {
+                return next(new Error('No name provided!'));
+            }
+
+            if (!appInfo.startcmd) {
+                return next(new Error('No start command provided!'));
+            }
+
+            self.log('Use start command "' + appInfo.startcmd + '".');
+
+            nssmExec(options.nssmPath, 'install', appInfo.name, appInfo.startcmd, options.silent, function(error) {
+                if (error) {
+                    return next(error);
+                }
+
+                self.log('The program "' + appInfo.name + '" was installed as a service.');
+                next();
+            });
+        },
+        function(next) {
+            nssmExec(options.nssmPath, 'set', appInfo.name, 'AppDirectory "' + appInfo.path + '"', options.silent, function(error) {
+                if (error) {
+                    return next(new Error('Can\'t set startup folder (' + appInfo.path + ') for service'));
+                }
+
+                next();
+            });
+        },
+        function(next) {
+            if (!appInfo.description) {
+                return next();
+            }
+
+            nssmExec(options.nssmPath, 'set', appInfo.name, 'Description "' + appInfo.description + '"', options.silent, function(error) {
+                if (error) {
+                    return next(new Error('Can\'t set description for service'));
+                }
+
+                next();
+            });
+        },
+        function(next) {
+            if (!appInfo.displayname) {
+                return next();
+            }
+
+            nssmExec(options.nssmPath, 'set', appInfo.name, 'DisplayName "' + appInfo.displayname + '"', options.silent, function(error) {
+                if (error) {
+                    return next(new Error('Can\'t set display name for service'));
+                }
+
+                next();
+            });
+        },
+        function(next) {
+            nssmExec(options.nssmPath, 'set', appInfo.name, 'Start ' + getStartupType(appInfo.startuptype), options.silent, function(error) {
+                if (error) {
+                    return next(new Error('Can\'t set startup type for service'));
+                }
+
+                next();
+            });
+        },
+        function(next) {
+            var envs;
+
+            if (localOpts && localOpts.env && localOpts.env.length > 0) {
+                envs = Array.isArray(localOpts.env) ? localOpts.env.join(' ') : localOpts.env;
+
+                nssmExec(options.nssmPath, 'set', appInfo.name, 'AppEnvironmentExtra ' + envs, options.silent, function(error) {
+                    if (error) {
+                        return next(new Error('Can\'t set environment for service'));
+                    }
+
+                    next();
+                });
+
+                return;
+            } else {
+                next();
+            }
+        },
+        function(next) {
+            if (!localOpts || !localOpts.set || localOpts.set.length === 0) {
+                return next();
+            }
+
+            async.each(localOpts.set, function(arg, callback) {
+                nssmExec(options.nssmPath, 'set', appInfo.name, arg, options.silent, function(error) {
+                  if (error) {
+                      return callback(new Error('Set operation failed (' + arg + ')'));
+                  }
+
+                  callback();
+                });
+            }, function(error) {
+                if (error) {
+                    return next(error);
+                }
+
+                next();
+            })
+        },
+        function(next) {
+            if (!autostart) {
+                return next();
+            }
+
+            nssmExec(options.nssmPath, 'start', appInfo.name, null, options.silent, function(error) {
+                if (error) {
+                    return next(error);
+                }
+
+                self.log('The service for "' + appInfo.name + '" was started.');
+                next();
+            });
+        }
+    ], cb);
+};
+
+Winser.prototype.remove = function remove(localOpts, cb) {
+    var self = this;
+    var options = assign({}, self._options);
+    var args = Array.prototype.slice.call(arguments);
+    var appInfo;
+    var stop;
+
+    if (localOpts && localOpts.path != null) {
+        options.path = localOpts.path;
+    }
+
+    if (args.length === 1) {
+        cb = localOpts;
+        stop = options.stop
+    } else {
+        if (localOpts && localOpts.stop != null) {
+            stop = localOpts.stop
+        } else {
+            stop = options.stop
+        }
+    }
+
+    async.waterfall([
+        function(next) {
+            checkRequerimentsAndApplyDefaults('remove', options, next);
+        },
+        function(opts, next) {
+            options = opts;
+
+            getAppInfoFromPkgOrOptions(options, {
+              name: localOpts && localOpts.name
+            }, next);
+        },
+        function(info, next) {
+            appInfo = info;
+
+            if (!appInfo.name) {
+                return next(new Error('No name provided!'));
+            }
+
+            if (!stop) {
+                return next();
+            }
+
+            exec(
+                options.nssmPath + ' status "' + appInfo.name + '"',
+                function(err, stdout, stderr) {
+                    if (!err && !stderr){
+                        var result = stdout.replace(/\0/gi, "").split("\r\n")[0];
+
+                        if (result === "SERVICE_STOPPED") {
+                            next();
+                        } else {
+                            nssmExec(options.nssmPath, 'stop', appInfo.name, null, options.silent, function() {
+                                next();
+                            });
+                        }
+
+                        return;
+                    }
+
+                    next(err || (stderr ? new Error(stderr) : null));
+                }
+            );
+        },
+        function(next) {
+            nssmExec(options.nssmPath, 'remove', appInfo.name, 'confirm', options.silent, function(error) {
+                if (error) {
+                    return next(error);
+                }
+
+                self.log('The service for "' + appInfo.name + '" was removed.');
+                next();
+            });
+        }
+    ], cb);
+}
+
+Winser.prototype.getAppInfo = function getAppInfo(localOpts, cb) {
+    var options = this._options;
+    var args = Array.prototype.slice.call(arguments);
+
+    if (args.length === 1) {
+        cb = localOpts;
+        localOpts = undefined;
+    }
+
+    getAppInfoFromPkgOrOptions(options, {
+        path: localOpts && localOpts.path,
+        name: localOpts && localOpts.name,
+        displayname: localOpts && localOpts.displayname,
+        description: localOpts && localOpts.description,
+        startwithnpm: localOpts && localOpts.startwithnpm,
+        startcmd: localOpts && localOpts.startcmd,
+        startuptype: localOpts && localOpts.startuptype
+    }, cb);
+}
+
+Winser.prototype.setSilent = function setSilent(silent) {
+    this._options.silent = silent;
+}
+
+function checkRequerimentsAndApplyDefaults(action, opts, cb) {
+    var options = opts = {};
+
+    async.series([
+        function(next) {
+            if (process.platform !== 'win32') {
+                return next(new Error('Winser can only install services on windows.'));
+            }
+
+            next()
+        },
+        function(next) {
+            exec('NET SESSION', function(err, stdout, stderr) {
+                if (err || stderr.length !== 0) {
+                    return next(new Error('No rights to manage services.'));
+                }
+
+                next();
+            });
+        },
+        function(next) {
+            if (options.app) {
+                return next();
+            }
+
+            if (!options.path) {
+                return next(new Error('No path provided!'));
+            }
+
+            if (!(fs.existsSync || path.existsSync)(path.join(options.path, "package.json"))) {
+                return next(new Error('"' + options.path + '" doesn\'t seems to be a node application path.\nIt doesn\'t contains a package.json file.'));
+            }
+
+            next();
+        },
+        function(next) {
+            if (action === 'install' && options.startwithnpm) {
+                exec('where npm.cmd', function(error, stdout) {
+                    if (error !== null) {
+                        return next(new Error('Can\'t find npm...'));
+                    }
+
+                    next();
+                });
+
+                return;
+            }
+
+            next();
+        },
+        function(next) {
+            if (options.nssmPath) {
+                options.nssmPath = '"' + options.nssmPath + '"';
+                return next();
+            }
+
+            exec('wmic CPU get AddressWidth < nul', function(err, stdout) {
+                var arch = '32';
+
+                if (!err && stdout) {
+                    arch = stdout.match(/(32|64)/)[1];
+                }
+
+                options.nssmPath = '"' + path.join(__dirname, (arch === '64') ? 'nssm64.exe' : 'nssm.exe') + '"';
+                next();
+            });
+        }
+    ], function (error) {
+        cb(error, options);
+    });
+}
+
+function getAppInfoFromPkgOrOptions(options, localOptions, cb) {
+    var appPackage;
+    var appPath;
+    var appInfo = options.app;
+    var info = {};
+    var startwithnpm;
+    var startcmd;
+    var startuptype;
+
+    if (localOptions && localOptions.path) {
+        appPath = localOptions.path;
+    } else if (appInfo && appInfo.path) {
+        appPath = appInfo.path;
+    } else {
+        appPath = options.path;
+    }
+
+    startwithnpm = localOptions.startwithnpm || appInfo.startwithnpm || options.startwithnpm;
+
+    if (startwithnpm) {
+        startcmd = 'npm start';
+    } else {
+        if (localOptions && localOptions.startcmd) {
+            startcmd = localOptions.startcmd;
+        } else if (appInfo && appInfo.startcmd) {
+            startcmd = appInfo.startcmd;
+        } else {
+            startcmd = options.startcmd;
+        }
+    }
+
+    if (localOptions && localOptions.startuptype) {
+        startuptype = localOptions.startuptype;
+    } else if (appInfo && appInfo.startuptype) {
+        startuptype = appInfo.startuptype;
+    } else {
+        startuptype = options.startuptype;
+    }
+
+    info.path = appPath;
+    info.startcmd = startcmd;
+    info.startuptype = startcmd;
+
+    if (appInfo) {
+        info.name = appInfo.name;
+        info.displayname = appInfo.displayname;
+        info.description = appInfo.description;
+    } else {
+        try {
+            appPackage = require(path.join(appPath, 'package.json'));
+
+            info.name = appPackage.name;
+            info.description = appPackage.description;
+
+            if (!info.startcmd) {
+                try {
+                    info.startcmd = appPackage.scripts.start;
+                } catch (e) {}
+
+                if (!info.startcmd) {
+                    info.startcmd = 'node ' + appPackage.main;
+                }
+            }
+        } catch (e) {
+            return cb(e);
+        }
+    }
+
+    // localOptions have more priority
+    if (localOptions) {
+        if (localOptions.name) {
+            info.name = localOptions.name;
+        }
+
+        if (localOptions.displayname) {
+            info.displayname = localOptions.displayname;
+        }
+
+        if (localOptions.description) {
+            info.description = localOptions.description;
+        }
+    }
+
+    cb(null, info);
+}
+
+function getStartupType(startuptype) {
+    switch (startuptype) {
+        case "auto":
+            return "SERVICE_AUTO_START";
+        case "delayed":
+            return "SERVICE_DELAYED_AUTO_START";
+        case "manual":
+            return "SERVICE_DEMAND_START";
+        case "disabled":
+            return "SERVICE_DISABLED";
+        default:
+            return "SERVICE_AUTO_START";
+    }
+}
+
+function nssmExec(nssmPath, command, serviceName, arguments, silent, callback) {
+    if (arguments === null) {
+        arguments = '';
+    }
+
+    exec(
+        nssmPath + ' ' + command + ' "' + serviceName + '" ' + arguments,
+        function(err, stdout, stderr) {
+            if (stderr){
+                !silent && console.error(stderr);
+            }
+
+            callback(err || (stderr ? new Error(stderr) : null));
+        }
+    );
+}
+
+module.exports = Winser();
+module.exports.Winser = Winser;
+module.exports.version = packageJson.version;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "winser",
   "version": "1.0.2",
   "description": "Run a node.js application as a window service using nssm.",
+  "main": "index.js",
   "keywords": [
     "windows",
     "services",
@@ -21,6 +22,7 @@
   "private": false,
   "dependencies": {
     "async": "0.9.0",
+    "object-assign": "4.1.1",
     "stdio": "0.2.2"
   },
   "bin": {


### PR DESCRIPTION
this PR adds a node.js API to the package and allow its usage from a node.js app  (`require('winser')` is now possible.), it also contains a fix for #40 

with this PR the following issues probably should be closed:  #40, #38, #34

please let me know if you are ok with this, and i would work on adding docs about the API

ping @jfromaniello for review.